### PR TITLE
Change values for the eventPhase on defaultEvent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,16 +93,17 @@ const defaultEvent = {
     eventPhase: 0,
     isTrusted: false,
     initEvent: () => {},
-    AT_TARGET: null,
-    BUBBLING_PHASE: null,
-    CAPTURING_PHASE: null,
-    NONE: null,
     composedPath: () => [],
     preventDefault: () => {},
     stopImmediatePropagation: () => {},
     stopPropagation: () => {},
     returnValue: true,
     srcElement: null,
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase
+    NONE: 0,
+    CAPTURING_PHASE: 1,
+    AT_TARGET: 2,
+    BUBBLING_PHASE: 3,
 };
 
 export const setMedia = (media: Partial<MediaState>) => {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase and what I observed, we could use the actual values from the `defaultEvent`




![image](https://user-images.githubusercontent.com/22725671/149860624-7a3c78ff-e13b-420d-bb47-92defb1d975d.png)

![image](https://user-images.githubusercontent.com/22725671/149860674-6c06b0a2-2413-4c97-b2cb-0d06c1d5e65d.png)
