### PR TITLE
In case of invalid query, fallback to 'not all'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,8 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
     try {
         matches = match(query, state);
     } catch (e) {
-        query = query.replace(/ /g, "_");
-        matches = match(query, state);
+        query = "not all";
+        matches = false;
     }
     return {
         matches,


### PR DESCRIPTION
When the query isn't valid in browsers, it falls back to `not all` + `matches: false`

![image](https://user-images.githubusercontent.com/22725671/149860876-5f9865ec-d070-4c19-96c0-afc984d2bb0f.png)
