### PR TITLE
Avoid mutating callbacks and storing on them the result of the previous match

### DIFF
--- a/src/css-mediaquery.d.ts
+++ b/src/css-mediaquery.d.ts
@@ -1,8 +1,19 @@
 declare module "css-mediaquery" {
-    export type Feature = string;
+    /**
+     * A query is a string like `(min-width: 50px), (max-height: 250px)`
+     */
+    export type Query = string & { __type: "media" };
+    /**
+     * Meaningful unit that composes queries.
+     *
+     * For instance, on query like `(min-width: 50px), (max-height: 250px)`, there are 2 features:
+     * - `width`
+     * - `height`
+     */
+    export type Feature = string & { __type: "feature" };
 
     export type MediaState = Record<Feature, string>;
-    type Match = (query: string, state: MediaState) => boolean;
+    type Match = (query: Query, state: MediaState) => boolean;
     export const match: Match;
 
     type Expression = {
@@ -15,6 +26,6 @@ declare module "css-mediaquery" {
         type: "all" | "print" | "screen" | "speech";
         expressions: Expression[];
     };
-    type Parse = (query: string) => MatchedMedia[];
+    type Parse = (query: Query) => MatchedMedia[];
     export const parse: Parse;
 }


### PR DESCRIPTION
This had 3 negative effects:
1. it mutates the function passed to it, so it can mess up with user code (if they also decided to store extra argument on the fn)
2. if the query previously stored was part of the prototype of the function, it can do some real harm
3. if was only storing 1 query per function, but the same fn (like console.log) could be used in a a lot of different event listeners

So instead, we store everything in a global map