### PR TITLE
Align with browsers behaviors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,10 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
         previousMatched = false;
     }
     const callbacks = new Set<Callback>();
-    const looseCallbacks = new WeakSet<Callback>();
     const onces = new WeakSet<Callback>();
 
     const clear = () => {
         for (const callback of callbacks) {
-            looseCallbacks.delete(callback);
             onces.delete(callback);
         }
         callbacks.clear();
@@ -41,7 +39,6 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
 
     const removeListener = (callback: Callback) => {
         callbacks.delete(callback);
-        looseCallbacks.delete(callback);
         onces.delete(callback);
     };
 
@@ -64,7 +61,7 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
         dispatchEvent: (event: MediaQueryListEvent) => {
             mql.onchange?.(event);
             callbacks.forEach((callback) => {
-                if (event.type === "change" || looseCallbacks.has(callback)) {
+                if (event.type === "change") {
                     callback(event);
                     if (onces.has(callback)) {
                         removeListener(callback);
@@ -77,7 +74,6 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
         },
         addListener: (callback) => {
             if (!callback) return;
-            looseCallbacks.add(callback);
             callbacks.add(callback);
         },
         removeListener: (callback) => {

--- a/tests/listeners.cjs
+++ b/tests/listeners.cjs
@@ -16,7 +16,7 @@ const mock = () => {
     ];
 };
 
-test.serial(".addListener()", (t) => {
+test.serial("`.addListener()`", (t) => {
     const mql = matchMedia("(min-width: 500px)");
 
     const [cb, calls] = mock();
@@ -60,7 +60,7 @@ test.serial(".addListener()", (t) => {
     t.pass();
 });
 
-test.serial(".addEventListener()", (t) => {
+test.serial("`.addEventListener()`", (t) => {
     const mql = matchMedia("(min-width: 500px)");
 
     const [cb, calls] = mock();
@@ -179,7 +179,7 @@ test.serial("ensure that when the same fn is used in 2 different MQL, it will be
     t.pass();
 });
 
-test.serial(".dispatchEvent() always calls listeners", (t) => {
+test.serial("`.dispatchEvent()` always calls listeners", (t) => {
     const mql1 = matchMedia("(min-width: 500px)");
     const mql2 = matchMedia("(min-width: 500px)");
 
@@ -199,7 +199,7 @@ test.serial(".dispatchEvent() always calls listeners", (t) => {
     t.pass();
 });
 
-test.serial(".dispatchEvent() is only dispatched once", (t) => {
+test.serial("`.dispatchEvent()` is only dispatched once", (t) => {
     const mql = matchMedia("(min-width: 500px)");
 
     const [cb, calls] = mock();
@@ -214,24 +214,27 @@ test.serial(".dispatchEvent() is only dispatched once", (t) => {
     t.pass();
 });
 
-test.serial(".dispatchEvent() always calls the listeners, not the event listeners when the event isn't change", (t) => {
-    const mql1 = matchMedia("(min-width: 500px)");
-    const mql2 = matchMedia("(min-width: 500px)");
+test.serial(
+    "`.dispatchEvent()` doesn’t call neither listeners, nor the event listeners when the event isn't `change`",
+    (t) => {
+        const mql1 = matchMedia("(min-width: 500px)");
+        const mql2 = matchMedia("(min-width: 500px)");
 
-    const [cb1, calls1] = mock();
-    const [cb2, calls2] = mock();
+        const [cb1, calls1] = mock();
+        const [cb2, calls2] = mock();
 
-    mql1.addEventListener("change", cb1);
-    mql2.addListener(cb2);
+        mql1.addEventListener("change", cb1);
+        mql2.addListener(cb2);
 
-    mql1.dispatchEvent(new MediaQueryListEvent("not-change", { matches: false, media: "(custom-non-valid)" }));
-    mql2.dispatchEvent(new MediaQueryListEvent("not-change", { matches: false, media: "(custom-non-valid)" }));
+        mql1.dispatchEvent(new MediaQueryListEvent("not-change", { matches: false, media: "(custom-non-valid)" }));
+        mql2.dispatchEvent(new MediaQueryListEvent("not-change", { matches: false, media: "(custom-non-valid)" }));
 
-    t.is(calls1.length, 0);
-    t.is(calls2.length, 1);
+        t.is(calls1.length, 0);
+        t.is(calls2.length, 0);
 
-    t.pass();
-});
+        t.pass();
+    },
+);
 
 test.serial("the 2 kinds of listeners can reset each other", (t) => {
     const mql1 = matchMedia("(min-width: 500px)");
@@ -291,7 +294,7 @@ test.serial("the listeners and onchange are fired twice when set together", (t) 
     t.is(calls2.length, 2);
 });
 
-test.serial("the listeners can't disable onchange", (t) => {
+test.serial("the listeners can't disable `onchange`", (t) => {
     const mql1 = matchMedia("(min-width: 500px)");
     const [cb1, calls1] = mock();
     mql1.onchange = cb1;
@@ -307,7 +310,7 @@ test.serial("the listeners can't disable onchange", (t) => {
     t.is(calls2.length, 1);
 });
 
-test.serial("once: true clears all listeners after 1 call", (t) => {
+test.serial("`once: true` doesn’t clear any listener after 1 call", (t) => {
     const mql = matchMedia("(min-width: 500px)");
     const [cb, calls] = mock();
     mql.addListener(cb);
@@ -317,17 +320,17 @@ test.serial("once: true clears all listeners after 1 call", (t) => {
     mql.dispatchEvent(new MediaQueryListEvent("change", { matches: false, media: "(custom-non-valid)" }));
     t.is(calls.length, 1);
 
-    // There is no more listener
+    // The other listeners are still here
     mql.dispatchEvent(new MediaQueryListEvent("change", { matches: false, media: "(custom-non-valid)" }));
-    t.is(calls.length, 1);
+    t.is(calls.length, 2);
 
     // It only clear once too
     mql.addEventListener("change", cb);
     mql.dispatchEvent(new MediaQueryListEvent("change", { matches: false, media: "(custom-non-valid)" }));
-    t.is(calls.length, 2);
+    t.is(calls.length, 3);
 });
 
-test.serial("once: true should be cleared after a regular removeEventListener", (t) => {
+test.serial("`once: true` should be cleared after a regular `removeEventListener`", (t) => {
     const mql = matchMedia("(min-width: 500px)");
     const [cb, calls] = mock();
     mql.addEventListener("change", cb, { once: true });

--- a/tests/listeners.cjs
+++ b/tests/listeners.cjs
@@ -258,6 +258,7 @@ test.serial("the 2 kinds of listeners can reset each other", (t) => {
     t.pass();
 });
 
+// Note: the concept of "loose" state disappeared from the codebase, but this test is kept to avoid regressions
 test.serial("the loose state should disappear after a removeListener", (t) => {
     const mql1 = matchMedia("(min-width: 500px)");
     const [cb1, calls1] = mock();


### PR DESCRIPTION
- Update tests to comply with browsers' behaviors
- Consider `addListener` as a regular `addEventListener('change')` like what browsers do
- The `once` flag can be overridden by other definitions

Fixes https://github.com/Ayc0/mock-match-media/issues/26
