### PR TITLE
[dispatchEvent] check argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,43 @@ import { match, parse, Feature, Query, MediaState } from "css-mediaquery";
 
 let state: MediaState = {};
 
+const now = Date.now();
+
+// Event was added in node 15, so until we drop the support for versions before it, we need to use this
+class EventLegacy {
+    type: "change";
+    timeStamp: number;
+
+    bubbles = false;
+    cancelBubble = false;
+    cancelable = false;
+    composed = false;
+    target = null;
+    currentTarget = null;
+    defaultPrevented = false;
+    eventPhase = 0;
+    isTrusted = false;
+    initEvent = () => {};
+    composedPath = () => [];
+    preventDefault = () => {};
+    stopImmediatePropagation = () => {};
+    stopPropagation = () => {};
+    returnValue = true;
+    srcElement = null;
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase
+    NONE = 0;
+    CAPTURING_PHASE = 1;
+    AT_TARGET = 2;
+    BUBBLING_PHASE = 3;
+    constructor(type: "change") {
+        this.type = type;
+        this.timeStamp = Date.now() - now; // See https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp#value
+    }
+}
+
+// @ts-expect-error
+const EventCompat: typeof Event = typeof Event === "undefined" ? EventLegacy : Event;
+
 const getFeaturesFromQuery = (query: Query): Set<Feature> => {
     const parsedQuery = parse(query);
     const features = new Set<Feature>();
@@ -75,6 +112,16 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
             if (event === "change") removeListener(callback);
         },
         dispatchEvent: (event: MediaQueryListEvent) => {
+            if (!event) {
+                throw new TypeError(
+                    `Failed to execute 'dispatchEvent' on 'EventTarget': 1 argument required, but only 0 present.`,
+                );
+            }
+            if (!(event instanceof EventCompat)) {
+                throw new TypeError(
+                    `Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.`,
+                );
+            }
             if (event.type !== "change") {
                 return true;
             }
@@ -107,43 +154,6 @@ export const matchMedia: typeof window.matchMedia = (query: string) => {
 
     return mql;
 };
-
-const now = Date.now();
-
-// Event was added in node 15, so until we drop the support for versions before it, we need to use this
-class EventLegacy {
-    type: "change";
-    timeStamp: number;
-
-    bubbles = false;
-    cancelBubble = false;
-    cancelable = false;
-    composed = false;
-    target = null;
-    currentTarget = null;
-    defaultPrevented = false;
-    eventPhase = 0;
-    isTrusted = false;
-    initEvent = () => {};
-    composedPath = () => [];
-    preventDefault = () => {};
-    stopImmediatePropagation = () => {};
-    stopPropagation = () => {};
-    returnValue = true;
-    srcElement = null;
-    // See https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase
-    NONE = 0;
-    CAPTURING_PHASE = 1;
-    AT_TARGET = 2;
-    BUBBLING_PHASE = 3;
-    constructor(type: "change") {
-        this.type = type;
-        this.timeStamp = Date.now() - now; // See https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp#value
-    }
-}
-
-// @ts-expect-error
-const EventCompat: typeof Event = typeof Event === "undefined" ? EventLegacy : Event;
 
 export class MediaQueryListEvent extends EventCompat {
     readonly media: string;

--- a/tests/listeners.cjs
+++ b/tests/listeners.cjs
@@ -342,3 +342,17 @@ test.serial("`once: true` should be cleared after a regular `removeEventListener
     mql.dispatchEvent(new MediaQueryListEvent("change", { matches: false, media: "(custom-non-valid)" }));
     t.is(calls.length, 2);
 });
+
+test.serial("`.dispatchEvent` can only receive events", (t) => {
+    const mql = matchMedia("(min-width: 500px)");
+    if (typeof Event !== "undefined") {
+        t.is(mql.dispatchEvent(new Event("hello")), true);
+    }
+    t.is(mql.dispatchEvent(new MediaQueryListEvent("change", { matches: false, media: "(custom-non-valid)" })), true);
+
+    const err1 = t.throws(() => mql.dispatchEvent());
+    t.is(err1.message, `Failed to execute 'dispatchEvent' on 'EventTarget': 1 argument required, but only 0 present.`);
+
+    const err2 = t.throws(() => mql.dispatchEvent("hello"));
+    t.is(err2.message, `Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.`);
+});


### PR DESCRIPTION
In the browsers, `dispatchEvent` crashes when not used with an Event. We could do the same thing here.