### PR TITLE
[types] fix path to types and add types in exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.mjs",
-    "types": "dist/index.d.js",
+    "types": "dist/index.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
             "import": "./dist/index.mjs",
             "browser": "./dist/index.mjs"


### PR DESCRIPTION
Fixes https://github.com/Ayc0/mock-match-media/issues/37