### PR TITLE
[BREAKING CHANGE] update supported node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 16.x, 18.x, 19.x]
+                node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
 
         steps:
             - uses: actions/checkout@v1


### PR DESCRIPTION
This is the update node versions:

<img width="771" alt="image" src="https://github.com/user-attachments/assets/437edde5-61ae-40d9-969a-f28be6a04951" />
