### PR TITLE
[BREAKING CHANGE] Update `height`, `width`, `deviceHeight` and `deviceWidth` in `setMedia` to be numbers instead of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@ Simple server-side compatible substitution for `window.matchMedia()` based on [c
 
 1. [What is `mock-match-media`?](#what-is-mock-match-media)
 2. [Usage](#usage)
-   1. [Listeners](#listeners)
-   2. [Cleanup](#cleanup)
-      1. [`cleanupListeners`](#cleanuplisteners)
-      2. [`cleanupMedia`](#cleanupmedia)
-      3. [`cleanup`](#cleanup-1)
-   3. [Polyfill](#polyfill)
-   4. [Other features](#other-features)
-      1. [`once` event listeners](#once-event-listeners)
-      2. [`.dispatchEvent` & `MediaQueryListEvent`](#dispatchevent--mediaquerylistevent)
-      3. [`.onchange`](#onchange)
-      4. [Interactions between multiple listeners](#interactions-between-multiple-listeners)
-   5. [ESM](#esm)
+    1. [Listeners](#listeners)
+    2. [Cleanup](#cleanup)
+        1. [`cleanupListeners`](#cleanuplisteners)
+        2. [`cleanupMedia`](#cleanupmedia)
+        3. [`cleanup`](#cleanup-1)
+    3. [Polyfill](#polyfill)
+    4. [Other features](#other-features)
+        1. [`once` event listeners](#once-event-listeners)
+        2. [`.dispatchEvent` & `MediaQueryListEvent`](#dispatchevent--mediaquerylistevent)
+        3. [`.onchange`](#onchange)
+        4. [Interactions between multiple listeners](#interactions-between-multiple-listeners)
+    5. [ESM](#esm)
 3. [How to use with other libraries](#how-to-use-with-other-libraries)
-   1. [Jest](#jest)
-   2. [NextJS](#nextjs)
+    1. [Jest](#jest)
+    2. [NextJS](#nextjs)
 
 # What is `mock-match-media`?
 
@@ -37,7 +37,7 @@ const { matchMedia, setMedia } = require("mock-match-media");
 
 // Define current media
 setMedia({
-    width: "50px",
+    width: 50,
     type: "screen",
     orientation: "landscape",
     "prefers-color-scheme": "light",
@@ -50,7 +50,7 @@ matchMedia("(min-width: 40px)").matches;
 
 // Only redefine what changed
 setMedia({
-    width: "500px",
+    width: 500,
 });
 
 matchMedia("(min-width: 250px)").matches;
@@ -65,7 +65,7 @@ matchMedia("(min-width: 250px)").matches;
 const { matchMedia, setMedia } = require("mock-match-media");
 
 setMedia({
-    width: "50px",
+    width: 50,
 });
 
 const listener = (event) => console.log(event.matches);
@@ -77,19 +77,19 @@ matcher.addEventListener("change", listener);
 // matchMedia("(min-width: 250px)").addListener(event => console.log(event.matches));
 
 setMedia({
-    width: "100px",
+    width: 100,
 });
 // outputs nothing because `matches` hasn't changed
 
 setMedia({
-    width: "1000px",
+    width: 1000,
 });
 // outputs `true`
 
 matcher.removeEventListener("change", listener);
 
 setMedia({
-    width: "100px",
+    width: 100,
 });
 // outputs nothing because the listener is removed
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,12 +171,23 @@ export class MediaQueryListEvent extends EventCompat {
     }
 }
 
+const PIXEL_FEATURES = ["width", "height", "deviceWidth", "deviceHeight"];
+
 // Cannot use MediaState here as setMedia is exposed in the API
-export const setMedia = (media: Record<string, string>) => {
+export const setMedia = (media: Record<string, string | number>) => {
     const changedFeatures = new Set<Feature>();
     Object.keys(media).forEach((feature) => {
         changedFeatures.add(feature as Feature);
-        state[feature] = media[feature];
+        let value;
+        if (PIXEL_FEATURES.includes(feature)) {
+            if (typeof media[feature] !== "number") {
+                throw new Error(feature + " expects number (pixel dimensions)");
+            }
+            value = media[feature] + "px";
+        } else {
+            value = media[feature];
+        }
+        state[feature] = value;
     });
     for (const [MQL, cache] of MQLs) {
         let found = false;

--- a/tests/listeners.cjs
+++ b/tests/listeners.cjs
@@ -24,27 +24,27 @@ test.serial("`.addListener()`", (t) => {
     mql.addListener(cb);
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(calls.length, 1);
     t.is(calls[0].matches, true);
 
     setMedia({
-        width: "300px",
+        width: 300,
     });
     t.is(calls.length, 2);
     t.is(calls[1].matches, false);
 
     // No new call
     setMedia({
-        width: "200px",
+        width: 200,
     });
     t.is(calls.length, 2);
 
     // cleanup make it so that new changes in the media won’t trigger listeners
     cleanupListeners();
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(calls.length, 2);
 
@@ -53,7 +53,7 @@ test.serial("`.addListener()`", (t) => {
     cleanup();
 
     setMedia({
-        width: "300px",
+        width: 300,
     });
     t.is(calls.length, 2);
 
@@ -68,27 +68,27 @@ test.serial("`.addEventListener()`", (t) => {
     mql.addEventListener("change", cb);
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(calls.length, 1);
     t.is(calls[0].matches, true);
 
     setMedia({
-        width: "300px",
+        width: 300,
     });
     t.is(calls.length, 2);
     t.is(calls[1].matches, false);
 
     // No new call
     setMedia({
-        width: "200px",
+        width: 200,
     });
     t.is(calls.length, 2);
 
     // cleanup make it so that new changes in the media won’t trigger listeners
     cleanupListeners();
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(calls.length, 2);
 
@@ -97,7 +97,7 @@ test.serial("`.addEventListener()`", (t) => {
     cleanup();
 
     setMedia({
-        width: "300px",
+        width: 300,
     });
     t.is(calls.length, 2);
 
@@ -115,21 +115,21 @@ test.serial("listeners get only called once when multiple features change", (t) 
     t.is(calls.length, 0);
 
     setMedia({
-        width: "300px",
-        height: "300px",
+        width: 300,
+        height: 300,
     });
     t.is(calls.length, 0);
 
     // here it checks that it won’t first apply width, see if it matches, then apply height, see if it matches
     setMedia({
-        width: "600px",
-        height: "100px",
+        width: 600,
+        height: 100,
     });
     t.is(calls.length, 0);
 
     setMedia({
-        width: "600px",
-        height: "300px",
+        width: 600,
+        height: 300,
     });
     t.is(calls.length, 1);
     t.is(calls[0].matches, true);
@@ -150,7 +150,7 @@ test.serial(
         mql.addListener(cb);
 
         setMedia({
-            width: "600px",
+            width: 600,
         });
         t.is(calls.length, 1);
 
@@ -172,7 +172,7 @@ test.serial("ensure that when the same fn is used in 2 different MQL, it will be
     mql4.addListener(cb);
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(calls.length, 4);
 

--- a/tests/simple-use.cjs
+++ b/tests/simple-use.cjs
@@ -7,13 +7,13 @@ test.serial(".matches", (t) => {
     t.is(mql.matches, false);
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
 
     t.is(mql.matches, true);
 
     setMedia({
-        width: "300px",
+        width: 300,
     });
 
     t.is(mql.matches, false);
@@ -25,7 +25,7 @@ test.serial("cleanupMedia", (t) => {
     const doesMatch = () => matchMedia("(min-width: 500px)").matches;
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(doesMatch(), true);
 
@@ -37,7 +37,7 @@ test.serial("cleanup", (t) => {
     const doesMatch = () => matchMedia("(min-width: 500px)").matches;
 
     setMedia({
-        width: "600px",
+        width: 600,
     });
     t.is(doesMatch(), true);
 


### PR DESCRIPTION
To prepare for https://github.com/Ayc0/mock-match-media/pull/35, we need to do that. 

But also the library doesn't really work with other units, like `em` or `vw` etc. So allowing strings could make it confusing as people could think they are supported when they are not. Enforcing numbers make it easier to grasp