### PR TITLE
[BREAKING CHANGES] drop node 18.x to support ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 22.x, 23.x, 24.x]
+                node-version: [20.x, 22.x, 23.x, 24.x]
 
         steps:
             - uses: actions/checkout@v1


### PR DESCRIPTION
Drop node 18.x was we need support for ESM for https://github.com/Ayc0/mock-match-media/pull/35