### PR TITLE
add tests for prefers-color-scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ setMedia({
     width: 50,
     type: "screen",
     orientation: "landscape",
-    "prefers-color-scheme": "light",
+    prefersColorScheme: "light",
 });
 
 matchMedia("(min-width: 250px)").matches;

--- a/tests/matchers/prefers-color-scheme.cjs
+++ b/tests/matchers/prefers-color-scheme.cjs
@@ -1,0 +1,37 @@
+// @ts-check
+
+const test = require("ava");
+const { matchMedia, setMedia, cleanupMedia } = require("mock-match-media");
+
+test.beforeEach(() => {
+    cleanupMedia();
+});
+
+test.serial("unset", (t) => {
+    t.is(matchMedia("(prefers-color-scheme: light)").matches, false);
+    t.is(matchMedia("(prefers-color-scheme: dark)").matches, false);
+
+    t.pass();
+});
+
+test.serial("light", (t) => {
+    setMedia({
+        prefersColorScheme: "light",
+    });
+
+    t.is(matchMedia("(prefers-color-scheme: light)").matches, true);
+    t.is(matchMedia("(prefers-color-scheme: dark)").matches, false);
+
+    t.pass();
+});
+
+test.serial("dark", (t) => {
+    setMedia({
+        prefersColorScheme: "dark",
+    });
+
+    t.is(matchMedia("(prefers-color-scheme: light)").matches, false);
+    t.is(matchMedia("(prefers-color-scheme: dark)").matches, true);
+
+    t.pass();
+});


### PR DESCRIPTION
I noticed that the docs were mentioning `prefers-color-scheme` but the new library seems to be using a different case. So I'm adding tests