### PR TITLE
add TextEncoder is Jest setup

### DIFF
--- a/jest-setup.cjs
+++ b/jest-setup.cjs
@@ -1,3 +1,9 @@
+// The library depends on TextEncoder, but JSDOM doesn’t include it (see https://github.com/jsdom/jsdom/issues/2524)
+if (typeof globalThis.TextEncoder === "undefined") {
+    const { TextEncoder } = require("node:util");
+    Object.assign(globalThis, { TextEncoder });
+}
+
 const { cleanup } = require("./dist/index.js");
 
 require("./polyfill.cjs");


### PR DESCRIPTION
To avoid this issue with Jest + JSDOM

<img width="395" height="64" alt="image" src="https://github.com/user-attachments/assets/d4a7dcab-6ae6-42b4-b63d-e68238bbc19a" />
